### PR TITLE
[feat] adds password complexity to sign up and reset password pages

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -7,6 +7,8 @@ import { H1, H4, P } from '@/styles/text';
 import COLORS from '@/styles/colors';
 import { SpacerDiv } from '@/app/(auth)/styles';
 import BigButton from '@/components/BigButton';
+import PasswordComplexity from '@/components/PasswordComplexity';
+
 import supabase from '@/api/supabase/createClient';
 import { useAuth } from '@/utils/AuthProvider';
 
@@ -16,6 +18,7 @@ export default function ResetPassword() {
   const [newPassword2, setNewPassword2] = useState('');
   const [canReset, setCanReset] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const [passwordComplexity, setPasswordComplexity] = useState(false);
   const { push } = useRouter();
 
   useEffect(() => {
@@ -54,15 +57,21 @@ export default function ResetPassword() {
           {errorMessage !== '' && <P $color={COLORS.redMid}>{errorMessage}</P>}
         </SpacerDiv>
         <SpacerDiv>
-          <TextInput
-            label="New Password"
-            placeholder="Password"
-            errorText={newPassword.length < 6 ? 'Invalid Password' : ''}
-            type="password"
-            id="newpass"
-            value={newPassword}
-            setValue={setNewPassword}
-          />
+          <SpacerDiv $gap={0.5}>
+            <TextInput
+              label="New Password"
+              placeholder="Password"
+              errorText={newPassword.length < 6 ? 'Invalid Password' : ''}
+              type="password"
+              id="newpass"
+              value={newPassword}
+              setValue={setNewPassword}
+            />
+            <PasswordComplexity
+              password={newPassword}
+              setComplexity={setPasswordComplexity}
+            />
+          </SpacerDiv>
           <TextInput
             label="Confirm New Password"
             placeholder="Password"

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -30,6 +30,10 @@ export default function ResetPassword() {
   }, []);
 
   const resetPassword = async () => {
+    if (!passwordComplexity) {
+      setErrorMessage('Password must meet complexity requirements');
+      return;
+    }
     if (newPassword !== newPassword2) {
       setErrorMessage('Passwords do not match.');
       return;
@@ -61,7 +65,6 @@ export default function ResetPassword() {
             <TextInput
               label="New Password"
               placeholder="Password"
-              errorText={newPassword.length < 6 ? 'Invalid Password' : ''}
               type="password"
               id="newpass"
               value={newPassword}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -21,7 +21,6 @@ export default function SignUp() {
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
   const [passwordComplexity, setPasswordComplexity] = useState(false);
-  // const { push } = useRouter();
 
   const validEmail = (e: string) => e !== '' && isEmail(e);
 
@@ -49,7 +48,6 @@ export default function SignUp() {
     } else {
       setEmailSentCount(1);
       setErrorMessage('');
-      // push('/verify-email');
     }
   };
   const handleResendEmail = async () => {

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -73,7 +73,7 @@ export default function SignUp() {
     <>
       {!emailSentCount && (
         <>
-          <SpacerDiv $gap={0.625}>
+          <SpacerDiv $gap={10}>
             <H1>Sign Up</H1>
             {errorMessage !== '' && (
               <P $color={COLORS.redMid}>{errorMessage}</P>
@@ -88,7 +88,7 @@ export default function SignUp() {
             value={email}
             setValue={setEmail}
           />
-          <SpacerDiv $gap={0.5}>
+          <SpacerDiv $gap={8}>
             <TextInput
               label="Password"
               placeholder="Password"

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ import { SpacerDiv, HorizontalDiv, H4Centered } from '@/app/(auth)/styles';
 import BigButton from '@/components/BigButton';
 import Button from '@/components/Button';
 import { useAuth } from '@/utils/AuthProvider';
+import PasswordComplexity from '@/components/PasswordComplexity';
 
 export default function SignUp() {
   const auth = useAuth();
@@ -19,6 +20,8 @@ export default function SignUp() {
   const [errorMessage, setErrorMessage] = useState('');
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
+  const [passwordComplexity, setPasswordComplexity] = useState(false);
+  // const { push } = useRouter();
 
   const validEmail = (e: string) => e !== '' && isEmail(e);
 
@@ -28,6 +31,10 @@ export default function SignUp() {
     setPasswordError(password !== '' ? '' : 'Invalid Password');
     if (!validEmail(email) || password === '') {
       setErrorMessage('');
+      return;
+    }
+    if (!passwordComplexity) {
+      setPasswordError('Password must meet complexity requirements');
       return;
     }
     setEmailError('');
@@ -81,15 +88,21 @@ export default function SignUp() {
             value={email}
             setValue={setEmail}
           />
-          <TextInput
-            label="Password"
-            placeholder="Password"
-            errorText={passwordError}
-            type="password"
-            id="password"
-            value={password}
-            setValue={setPassword}
-          />
+          <SpacerDiv $gap={0.5}>
+            <TextInput
+              label="Password"
+              placeholder="Password"
+              errorText={passwordError}
+              type="password"
+              id="password"
+              value={password}
+              setValue={setPassword}
+            />
+            <PasswordComplexity
+              password={password}
+              setComplexity={setPasswordComplexity}
+            />
+          </SpacerDiv>
           <SpacerDiv>
             <BigButton type="button" onClick={handleSignUp}>
               Sign Up

--- a/src/app/(auth)/styles.tsx
+++ b/src/app/(auth)/styles.tsx
@@ -24,7 +24,7 @@ export const FormDiv = styled.div`
 export const SpacerDiv = styled.div<{ $gap?: number }>`
   display: flex;
   flex-direction: column;
-  gap: ${({ $gap }) => $gap || 1.2}rem;
+  gap: ${({ $gap }) => $gap || 19.2}px;
 `;
 
 export const H4Centered = styled(H4)`

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -31,17 +31,24 @@ function PasswordRequirement({ met, text }: { met: boolean; text: string }) {
   );
 }
 
+function isExistingPassword(password: string) {
+  return password.length > 0; // TODO: replace with a check to see if the password allows the user to log in once we have auth context
+}
+
 export default function PasswordComplexity({
   password,
   setComplexity,
+  isReset = false,
 }: {
   password: string;
   setComplexity: Dispatch<SetStateAction<boolean>>;
+  isReset?: boolean;
 }) {
   const hasUpperCase = /[A-Z]/.test(password);
   const hasLowerCase = /[a-z]/.test(password);
   const hasNumber = /\d/.test(password);
   const longEnough = password.length >= 8;
+  const existingPassword = isReset ? isExistingPassword(password) : true;
 
   if (hasUpperCase && hasLowerCase && hasNumber && longEnough) {
     setComplexity(true);
@@ -62,6 +69,10 @@ export default function PasswordComplexity({
         />
         <PasswordRequirement met={hasNumber} text="At least 1 number" />
         <PasswordRequirement met={longEnough} text="At least 8 characters" />
+        <PasswordRequirement
+          met={existingPassword}
+          text="New password must be different from previous password"
+        />
       </PasswordComplexityDiv>
     );
   }

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -41,7 +41,7 @@ export default function PasswordComplexity({
   const hasUpperCase = /[A-Z]/.test(password);
   const hasLowerCase = /[a-z]/.test(password);
   const hasNumber = /\d/.test(password);
-  const longEnough = password.length >= 12;
+  const longEnough = password.length >= 8;
 
   if (hasUpperCase && hasLowerCase && hasNumber && longEnough) {
     setComplexity(true);
@@ -61,7 +61,7 @@ export default function PasswordComplexity({
           text="At least 1 lowercase character"
         />
         <PasswordRequirement met={hasNumber} text="At least 1 number" />
-        <PasswordRequirement met={longEnough} text="At least 12 characters" />
+        <PasswordRequirement met={longEnough} text="At least 8 characters" />
       </PasswordComplexityDiv>
     );
   }

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -41,10 +41,9 @@ export default function PasswordComplexity({
   const hasUpperCase = /[A-Z]/.test(password);
   const hasLowerCase = /[a-z]/.test(password);
   const hasNumber = /\d/.test(password);
-  const hasSpecial = /[!@#$%^&*(),.?":{}|<>]/.test(password);
-  const longEnough = password.length >= 8;
+  const longEnough = password.length >= 12;
 
-  if (longEnough && hasUpperCase && hasLowerCase && hasNumber && hasSpecial) {
+  if (hasUpperCase && hasLowerCase && hasNumber && longEnough) {
     setComplexity(true);
   } else {
     setComplexity(false);
@@ -62,11 +61,7 @@ export default function PasswordComplexity({
           text="At least 1 lowercase character"
         />
         <PasswordRequirement met={hasNumber} text="At least 1 number" />
-        <PasswordRequirement
-          met={hasSpecial}
-          text="At least 1 special character"
-        />
-        <PasswordRequirement met={longEnough} text="At least 8 characters" />
+        <PasswordRequirement met={longEnough} text="At least 12 characters" />
       </PasswordComplexityDiv>
     );
   }

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -1,0 +1,81 @@
+import styled from 'styled-components';
+import { openSans } from '@/styles/fonts';
+import COLORS from '@/styles/colors';
+import { Dispatch, SetStateAction } from 'react';
+import Icon from './Icon';
+
+const PasswordComplexityDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+`;
+
+const PasswordRequirementDiv = styled.div<{ met: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const PasswordRequirementText = styled.p<{ met: boolean }>`
+  ${openSans.style}
+  color: ${props => (props.met ? COLORS.green : COLORS.greyMid)};
+`;
+
+export default function PasswordComplexity({
+  password,
+  setComplexity,
+}: {
+  password: string;
+  setComplexity: Dispatch<SetStateAction<boolean>>;
+}) {
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasNumber = /\d/.test(password);
+  const hasSpecial = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+  const longEnough = password.length >= 8;
+
+  if (longEnough && hasUpperCase && hasLowerCase && hasNumber && hasSpecial) {
+    setComplexity(true);
+  } else {
+    setComplexity(false);
+  }
+
+  if (password.length > 0) {
+    return (
+      <PasswordComplexityDiv>
+        <PasswordRequirementDiv met={longEnough}>
+          <Icon type={hasUpperCase ? 'green_check' : 'gray_dot'} />
+          <PasswordRequirementText met={hasUpperCase}>
+            At least 1 uppercase character
+          </PasswordRequirementText>
+        </PasswordRequirementDiv>
+        <PasswordRequirementDiv met={hasLowerCase}>
+          <Icon type={hasLowerCase ? 'green_check' : 'gray_dot'} />
+          <PasswordRequirementText met={hasLowerCase}>
+            At least 1 lowercase character
+          </PasswordRequirementText>
+        </PasswordRequirementDiv>
+        <PasswordRequirementDiv met={hasNumber}>
+          <Icon type={hasNumber ? 'green_check' : 'gray_dot'} />
+          <PasswordRequirementText met={hasNumber}>
+            At least 1 number
+          </PasswordRequirementText>
+        </PasswordRequirementDiv>
+        <PasswordRequirementDiv met={hasSpecial}>
+          <Icon type={hasSpecial ? 'green_check' : 'gray_dot'} />
+          <PasswordRequirementText met={hasSpecial}>
+            At least 1 special character
+          </PasswordRequirementText>
+        </PasswordRequirementDiv>
+        <PasswordRequirementDiv met={longEnough}>
+          <Icon type={longEnough ? 'green_check' : 'gray_dot'} />
+          <PasswordRequirementText met={longEnough}>
+            At least 8 characters
+          </PasswordRequirementText>
+        </PasswordRequirementDiv>
+      </PasswordComplexityDiv>
+    );
+  }
+  return null;
+}

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -31,24 +31,17 @@ function PasswordRequirement({ met, text }: { met: boolean; text: string }) {
   );
 }
 
-function isExistingPassword(password: string) {
-  return password.length > 0; // TODO: replace with a check to see if the password allows the user to log in once we have auth context
-}
-
 export default function PasswordComplexity({
   password,
   setComplexity,
-  isReset = false,
 }: {
   password: string;
   setComplexity: Dispatch<SetStateAction<boolean>>;
-  isReset?: boolean;
 }) {
   const hasUpperCase = /[A-Z]/.test(password);
   const hasLowerCase = /[a-z]/.test(password);
   const hasNumber = /\d/.test(password);
   const longEnough = password.length >= 8;
-  const existingPassword = isReset ? isExistingPassword(password) : true;
 
   if (hasUpperCase && hasLowerCase && hasNumber && longEnough) {
     setComplexity(true);
@@ -69,10 +62,6 @@ export default function PasswordComplexity({
         />
         <PasswordRequirement met={hasNumber} text="At least 1 number" />
         <PasswordRequirement met={longEnough} text="At least 8 characters" />
-        <PasswordRequirement
-          met={existingPassword}
-          text="New password must be different from previous password"
-        />
       </PasswordComplexityDiv>
     );
   }

--- a/src/components/PasswordComplexity.tsx
+++ b/src/components/PasswordComplexity.tsx
@@ -22,6 +22,15 @@ const PasswordRequirementText = styled.p<{ met: boolean }>`
   color: ${props => (props.met ? COLORS.green : COLORS.greyMid)};
 `;
 
+function PasswordRequirement({ met, text }: { met: boolean; text: string }) {
+  return (
+    <PasswordRequirementDiv met={met}>
+      <Icon type={met ? 'green_check' : 'gray_dot'} />
+      <PasswordRequirementText met={met}>{text}</PasswordRequirementText>
+    </PasswordRequirementDiv>
+  );
+}
+
 export default function PasswordComplexity({
   password,
   setComplexity,
@@ -44,36 +53,20 @@ export default function PasswordComplexity({
   if (password.length > 0) {
     return (
       <PasswordComplexityDiv>
-        <PasswordRequirementDiv met={longEnough}>
-          <Icon type={hasUpperCase ? 'green_check' : 'gray_dot'} />
-          <PasswordRequirementText met={hasUpperCase}>
-            At least 1 uppercase character
-          </PasswordRequirementText>
-        </PasswordRequirementDiv>
-        <PasswordRequirementDiv met={hasLowerCase}>
-          <Icon type={hasLowerCase ? 'green_check' : 'gray_dot'} />
-          <PasswordRequirementText met={hasLowerCase}>
-            At least 1 lowercase character
-          </PasswordRequirementText>
-        </PasswordRequirementDiv>
-        <PasswordRequirementDiv met={hasNumber}>
-          <Icon type={hasNumber ? 'green_check' : 'gray_dot'} />
-          <PasswordRequirementText met={hasNumber}>
-            At least 1 number
-          </PasswordRequirementText>
-        </PasswordRequirementDiv>
-        <PasswordRequirementDiv met={hasSpecial}>
-          <Icon type={hasSpecial ? 'green_check' : 'gray_dot'} />
-          <PasswordRequirementText met={hasSpecial}>
-            At least 1 special character
-          </PasswordRequirementText>
-        </PasswordRequirementDiv>
-        <PasswordRequirementDiv met={longEnough}>
-          <Icon type={longEnough ? 'green_check' : 'gray_dot'} />
-          <PasswordRequirementText met={longEnough}>
-            At least 8 characters
-          </PasswordRequirementText>
-        </PasswordRequirementDiv>
+        <PasswordRequirement
+          met={hasUpperCase}
+          text="At least 1 uppercase character"
+        />
+        <PasswordRequirement
+          met={hasLowerCase}
+          text="At least 1 lowercase character"
+        />
+        <PasswordRequirement met={hasNumber} text="At least 1 number" />
+        <PasswordRequirement
+          met={hasSpecial}
+          text="At least 1 special character"
+        />
+        <PasswordRequirement met={longEnough} text="At least 8 characters" />
       </PasswordComplexityDiv>
     );
   }

--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -41,6 +41,31 @@ export const IconSvgs = {
       />
     </svg>
   ),
+  green_check: (
+    <svg
+      width="17"
+      height="12"
+      viewBox="0 0 17 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.58471 9.46756L1.79164 5.73602L0.5 6.99776L5.58471 12L16.5 1.26174L15.2175 0L5.58471 9.46756Z"
+        fill="#2E9D1B"
+      />
+    </svg>
+  ),
+  gray_dot: (
+    <svg
+      fill="#818181"
+      width="15"
+      height="15"
+      viewBox="0 0 15 15"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M7.8 10a2.2 2.2 0 0 0 4.4 0 2.2 2.2 0 0 0-4.4 0z" />
+    </svg>
+  ),
 };
 
 export type IconType = keyof typeof IconSvgs;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -18,6 +18,8 @@ const COLORS = {
   redDark: '#B53839',
   redLight: '#F3B1B2',
   redLighter: '#FFE9E9',
+  // Success Green
+  green: '#2E9D1B',
 };
 
 export default COLORS;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -18,7 +18,6 @@ const COLORS = {
   redDark: '#B53839',
   redLight: '#F3B1B2',
   redLighter: '#FFE9E9',
-  // Success Green
   green: '#2E9D1B',
 };
 


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## :tanabata_tree: Description

### :palm_tree: What's new in this PR
[//]: # "REQUIRED - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

This PR adds a component with hints about password complexity requirements to both the sign up and reset password pages, which are the two instances in the application where the user needs to pick a new password for their account.

The password should contain:
- at least one lowercase letter
- at least one uppercase letter
- at least 1 number
- at least 1 special character
- a minimum of 8 characters

THINGS I MISSED:
- Did not add the password complexity requirement "Must be different from your old email password" for reset password. This is because I was thinking this would be easier once I merge in the AuthContext -- we will need to pull the hashed password for the user from Supabase auth and then compare it to the hashed version of the new password, and I was thinking of adding a function to do this in the `AuthContext`? But very open to feedback on this plan!
- Could not test the reset password page because in order to get there, we need to access the reset password page through a link that is sent via email, but I hit the email rate limit lol

### :evergreen_tree: Screenshots
[//]: # "REQUIRED for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy! If you are making changes here, please CC: @kyrenetam at the bottom."

PASSWORD COMPLEXITY NOT MET
<img width="1512" alt="Screenshot 2024-03-10 at 5 12 22 PM" src="https://github.com/calblueprint/immigration-justice-project/assets/47801900/21e2ae9b-e09b-4985-9b5e-dca532c0c78b">

SIGN UP BUTTON PRESSED WITHOUT PASSWORD COMPLEXITY MET
<img width="1512" alt="Screenshot 2024-03-10 at 5 12 52 PM" src="https://github.com/calblueprint/immigration-justice-project/assets/47801900/2fc0924b-12aa-4d50-93de-36b25c24085b">

PASSWORD COMPLEXITY MET (sorry idk why i'm yelling)
<img width="1512" alt="Screenshot 2024-03-10 at 5 12 38 PM" src="https://github.com/calblueprint/immigration-justice-project/assets/47801900/b727000c-311e-4daa-9447-f241133e6d33">


### :potted_plant: Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"

## :deciduous_tree: How to review
[//]: # 'REQUIRED - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'



## :seedling: Next steps 
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."

Add the "new password is not the same as old password" requirement to the reset password `PasswordComplexity` requirement.

## :link: Relevant Links



### :information_source: Online sources
[//]: # 'Optional - copy links to any tutorials or documentation that was useful to you when working on this PR'


#64 #27 #35 

[//]: # 'This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
CC: @varortz @kyrenetam 
