### PR TITLE
[fix] make listing pages fit to screen height

### DIFF
--- a/src/components/ListingPage/styles.ts
+++ b/src/components/ListingPage/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import CONFIG from '@/lib/configs';
 import COLORS from '@/styles/colors';
 import { sans } from '@/styles/fonts';
 import { H4 } from '@/styles/text';
@@ -20,7 +21,7 @@ export const FiltersContainer = styled.div`
 `;
 
 export const PageContainer = styled.div`
-  height: 100svh;
+  height: calc(100svh - ${CONFIG.navbarHeight}px);
   width: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## :tanabata_tree: Description

### :palm_tree: What's new in this PR
[//]: # "REQUIRED - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

Fixed height of listing pages to match that of the screen height, thereby removing the third scrollbar

[//]: # 'This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
CC: @varortz, @kyrenetam 
