### PR TITLE
[fix] updates displayed value for null fields for consistency

### DIFF
--- a/src/components/ListingCard/index.tsx
+++ b/src/components/ListingCard/index.tsx
@@ -73,7 +73,7 @@ export default function ListingCard({
   const remoteInfo = useMemo(() => {
     if (listing.listing_type === 'CASE' || listing.listing_type === 'INT') {
       if (listing.is_remote === null || listing.is_remote === undefined) {
-        return 'Not Available';
+        return 'To Be Determined';
       }
       return listing.is_remote ? 'Remote' : 'In Person';
     }


### PR DESCRIPTION
[//]: # "These comments are meant for your reference. They are invisible and don't need to be deleted!"

## :tanabata_tree: Description

Updates the displayed value of null fields to stay consistent with the `ListingDetails` component.

### :palm_tree: What's new in this PR
[//]: # "REQUIRED - Describe what's new in this PR in a few lines. A description and bullet points for specifics will suffice."

Changes the Remote/In-Person field from "Not Available" to "To Be Determined" when the value is null.

### :evergreen_tree: Screenshots
[//]: # "REQUIRED for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy! If you are making changes here, please CC: @kyrenetam at the bottom."

<img width="1440" alt="image" src="https://github.com/calblueprint/immigration-justice-project/assets/84427964/5114764a-2cc7-48f1-a2b4-1af28b82ed95">


## :deciduous_tree: How to review
[//]: # 'REQUIRED - Describe the order in which to review files and what to expect when testing locally. Is there anything specifically you want feedback on? Should this be reviewed commit by commit, or all at once? What are some user flows to test? What are some edge cases to look out for?'



## :seedling: Next steps 
[//]: # "Optional - What's NOT in this PR, doesn't work yet, and/or still needs to be done. Note any temporary fixes in this PR that should be cleaned up later."



## :link: Relevant Links



### :information_source: Online sources
[//]: # 'Optional - copy links to any tutorials or documentation that was useful to you when working on this PR'



### :potted_plant: Related PRs
[//]: # "Optional - related PRs you're waiting on/ PRs that will conflict, etc; if this is a refactor, feel free to add PRs that previously modified this code"



[//]: # 'This tags the project leader as a default. Feel free to change, or add on anyone who you should be in on the conversation.'
CC: @varortz
